### PR TITLE
Screenlock on Windows fix

### DIFF
--- a/src/lib/powershell.js
+++ b/src/lib/powershell.js
@@ -115,8 +115,8 @@ const getScreenLockTimeout = async () => {
 
     // values come back as hex, convert to int Seconds
     response = {
-      pluggedIn: parseInt(data['Current AC Power Setting Index'], 16),
-      battery: parseInt(data['Current DC Power Setting Index'], 16)
+      pluggedIn: parseInt(data['Current AC Power Setting Index'], 16) || Infinity,
+      battery: parseInt(data['Current DC Power Setting Index'], 16) || Infinity
     }
   }
 


### PR DESCRIPTION
 Previously was satisfying < maxTimeout check when set to NEVER because the value was 0. Updated to convert `0` value to `Infinity`