### PR TITLE
Added powershell.dispose() calls each time powershell is invoked by node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Stethoscope",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": true,
   "homepage": "./",
   "author": "Netflix",

--- a/src/App.js
+++ b/src/App.js
@@ -192,7 +192,7 @@ class App extends Component {
   }
 
   scan = () => {
-    this.setState({ scanIsRunning: true }, () => {
+    this.setState({ loading: true, scanIsRunning: true }, () => {
       Stethoscope.validate(this.state.policy).then(({ device, result }) => {
         const lastScanTime = Date.now()
         this.setState({

--- a/src/Device.js
+++ b/src/Device.js
@@ -95,10 +95,6 @@ class Device extends Component {
     let deviceInfo = null
 
     if (this.state.showInfo) {
-      const macAddresses = device.macAddresses
-        .filter(({mac}) => mac !== '00:00:00:00:00:00')
-        .map(({mac}, i) => <li key={i}>{mac}</li>)
-
       deviceInfo = (
         <div className='deviceInfo'>
           <dl className='device-info'>
@@ -108,11 +104,6 @@ class Device extends Component {
             <dt>Platform</dt><dd>{device.platform}&nbsp;</dd>
             <dt>OS Version</dt><dd>{device.osVersion}&nbsp;</dd>
             <dt>Name</dt><dd>{device.deviceName}&nbsp;</dd>
-            <dt>MAC addresses</dt>
-            <dd>
-              <ul className='mac-addresses'>{macAddresses}</ul>
-              {macAddresses.length ? null : <span>&nbsp;</span>}
-            </dd>
             <dt>Serial</dt><dd>{device.hardwareSerial}&nbsp;</dd>
             <dt>UDID</dt><dd>{device.deviceId}&nbsp;</dd>
             <dt>Status</dt><dd>{scanResult.status}&nbsp;</dd>

--- a/src/lib/Stethoscope.js
+++ b/src/lib/Stethoscope.js
@@ -103,21 +103,6 @@ export default class Stethoscope {
           encrypted
         }
 
-        ipAddresses {
-          interface
-          address
-          mask
-          broadcast
-        }
-
-        macAddresses {
-          interface
-          type
-          mac
-          lastChange
-          physicalAdapter
-        }
-
         security {
           firewall
           publicFirewall

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,34 @@
+const { app } = require('electron')
+const winston = require('winston')
+const path = require('path')
+require('winston-daily-rotate-file')
+const pkg = require('../../package.json')
+
+let log
+
+if (!global.log) {
+  // setup winston logging
+  const transport = new (winston.transports.DailyRotateFile)({
+    filename: 'application-%DATE%.log',
+    datePattern: 'YYYY-MM-DD',
+    dirname: path.resolve(app.getPath('userData')),
+    zippedArchive: true,
+    maxSize: '20m',
+    maxFiles: '3d'
+  })
+  const consoleTransport = new winston.transports.Console()
+  log = new winston.Logger({
+    rewriters: [(level, msg, meta) => {
+      meta.version = pkg.version
+      return meta
+    }],
+    transports: [
+      transport,
+      consoleTransport
+    ]
+  })
+  global.log = log
+}
+
+// make the winston logger available to the renderer
+module.exports = log

--- a/src/lib/powershell.js
+++ b/src/lib/powershell.js
@@ -17,7 +17,7 @@ const execPowershell = async (cmd) => {
   } catch (e) {
     ps.dispose()
     log.error(`powershell error: ${e} | cmd: ${cmd}`)
-    throw new Exception(e)
+    throw new Error(e)
   }
 }
 

--- a/src/lib/powershell.js
+++ b/src/lib/powershell.js
@@ -1,4 +1,4 @@
-const { UNSUPPORTED } = require('../constants')
+const { UNSUPPORTED, UNKNOWN } = require('../constants')
 const Shell = require('node-powershell')
 
 /*
@@ -59,7 +59,7 @@ const getScreenLockActive = async () => {
     `$name = 'ScreenSaveActive'`,
     '(Get-ItemProperty -Path $key -Name $name).$name'
   ]
-  const output = execPowershell(commands.join(';'))
+  const output = await execPowershell(commands.join(';'))
 
   if (output === UNKNOWN) return UNKNOWN
   return output.includes('1')

--- a/src/lib/powershell.js
+++ b/src/lib/powershell.js
@@ -5,7 +5,7 @@ const log = require('./logger')
 /*
   NOTE: Don't call node-powershell directly, use this `execPowershell` interface instead
 */
-const execPowershell = async (cmd) => {
+const execPowershell = async (cmd, logError = true) => {
   const ps = new Shell({
     debugMsg: false
   })
@@ -16,7 +16,9 @@ const execPowershell = async (cmd) => {
     return output
   } catch (e) {
     ps.dispose()
-    log.error(`powershell error: ${e} | cmd: ${cmd}`)
+    if (logError !== false) {
+      log.error(`powershell error: ${e} | cmd: ${cmd}`)
+    }
     throw new Error(e)
   }
 }
@@ -116,9 +118,13 @@ const getDisableLockWorkStation = async () => {
     '$key = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"',
     '(Get-ItemProperty -Path $key -Name $name).$name'
   ]
-  const output = await execPowershell(commands.join('; '))
 
-  return output !== UNKNOWN
+  try {
+    const output = await execPowershell(commands.join('; '), false)
+    return true
+  } catch (e) {
+    return false
+  }
 }
 
 const disks = async (disks = []) => {

--- a/src/lib/powershell.js
+++ b/src/lib/powershell.js
@@ -32,11 +32,10 @@ const getUserId = async () => {
   }
 
   const ps = new Shell(shellOptions)
-  let output = ''
 
   ps.addCommand('[System.Security.Principal.WindowsIdentity]::GetCurrent().User | Select Value')
   try {
-    output = await ps.invoke()
+    const output = await ps.invoke()
     ps.dispose()
     // cache for an hour
     cache.set('getUserId', 1000 * 60 * 60)

--- a/src/lib/powershell.js
+++ b/src/lib/powershell.js
@@ -1,107 +1,68 @@
 const { UNSUPPORTED } = require('../constants')
 const Shell = require('node-powershell')
-const Cache = require('./Cache')
 
-const cache = new Cache()
-const shellOptions = {
-  debugMsg: false
-}
-
-const openPreferences = pane => {
-  const cmd = `Get-ControlPanelItem *${pane.replace(/[^\w]/g, '')}* | Show-ControlPanelItem`
-  const ps = new Shell(shellOptions)
+/*
+  NOTE: Don't call node-powershell directly, use this `execPowershell` interface instead
+*/
+const execPowershell = async (cmd) => {
+  const ps = new Shell({
+    debugMsg: false
+  })
   ps.addCommand(cmd)
-  return ps.invoke().then(output => {
-    ps.dispose()
-    return output
-  }).catch(err => ps.dispose())
-}
-
-const run = cmd => {
-  const ps = new Shell(shellOptions)
-  ps.addCommand(cmd)
-  return ps.invoke().then(output => {
-    ps.dispose()
-    return output
-  }).catch(err => ps.dispose())
-}
-
-const getUserId = async () => {
-  if (cache.has('getUserId')) {
-    return cache.get('getUserId')
-  }
-
-  const ps = new Shell(shellOptions)
-
-  ps.addCommand('[System.Security.Principal.WindowsIdentity]::GetCurrent().User | Select Value')
   try {
     const output = await ps.invoke()
     ps.dispose()
-    // cache for an hour
-    cache.set('getUserId', 1000 * 60 * 60)
-    return output.split(/[\r\n]+/).pop()
+    return output
   } catch (e) {
     ps.dispose()
     return UNKNOWN
   }
+}
 
+const openPreferences = pane => {
+  return execPowershell(`Get-ControlPanelItem *${pane.replace(/[^\w]/g, '')}* | Show-ControlPanelItem`)
+}
+
+const run = cmd => execPowershell(cmd)
+
+const getUserId = async () => {
+  const output = await execPowershell('[System.Security.Principal.WindowsIdentity]::GetCurrent().User | Select Value')
+
+  if (output !== UNKNOWN) {
+    return output.split(/[\r\n]+/).pop()
+  }
+
+  return output
 }
 
 const firewallStatus = async () => {
-  if (cache.get('firewallStatus')) {
-    return cache.get('firewallStatus')
-  }
+  const output = await execPowershell('netsh advfirewall show allprofiles')
 
-  const ps = new Shell(shellOptions)
-  ps.addCommand('netsh advfirewall show allprofiles')
-
-  try {
-    const output = await ps.invoke().then((output) => {
-      ps.dispose()
-      const firewalls = ['domainFirewall', 'privateFirewall', 'publicFirewall']
-      return output.match(/State[\s\t]*(ON|OFF)/g).reduce((p, c, i) => {
-        p[firewalls[i]] = c.includes('ON') ? 'ON' : 'OFF'
-        return p
-      }, {})
-    })
-
-    // cache for 10 seconds
-    cache.set('firewallStatus', output, 1000 * 10)
-    return output
-  } catch (e) {
-    ps.dispose()
+  if (output === UNKNOWN) {
     return {
       domainFirewall: UNKNOWN,
       privateFirewall: UNKNOWN,
       publicFirewall: UNKNOWN
     }
+  } else {
+    const firewalls = ['domainFirewall', 'privateFirewall', 'publicFirewall']
+    return output.match(/State[\s\t]*(ON|OFF)/g).reduce((p, c, i) => {
+      p[firewalls[i]] = c.includes('ON') ? 'ON' : 'OFF'
+      return p
+    }, {})
   }
-
 }
 
 const getScreenLockActive = async () => {
-  if (cache.get('getScreenLockActive')) {
-    return cache.get('getScreenLockActive')
-  }
-
-  const ps = new Shell(shellOptions)
   const commands = [
     `$key = 'HKCU:\\Control Panel\\Desktop'`,
     `$name = 'ScreenSaveActive'`,
     '(Get-ItemProperty -Path $key -Name $name).$name'
   ]
-  ps.addCommand(commands.join(';'))
-  try {
-    const output = await ps.invoke()
-    ps.dispose()
-    // cache for 10 seconds
-    cache.set('getScreenLockActive', output.includes('1'), 1000 * 10)
-    return output.includes('1')
-  } catch (e) {
-    ps.dispose()
-    return UNKNOWN
-  }
+  const output = execPowershell(commands.join(';'))
 
+  if (output === UNKNOWN) return UNKNOWN
+  return output.includes('1')
 }
 
 // I'm sorry
@@ -111,15 +72,8 @@ const getScreenLockActive = async () => {
 // the subkeys (DISPLAY > SCREEN SLEEP) under that. The output is incredibly
 // verbose, hence all of the string parsing.
 const getScreenLockTimeout = async () => {
-  if (cache.get('getScreenLockTimeout')) {
-    return cache.get('getScreenLockTimeout')
-  }
-
-  const ps = new Shell(shellOptions)
   // determine the GUID of the user's active power scheme
-  ps.addCommand('powercfg /getactivescheme')
-  const output = await ps.invoke()
-  ps.dispose()
+  const output = await execPowershell('powercfg /getactivescheme')
 
   const match = output.match(/:\s([\w-]+)/)
   let activePowerGUID = null
@@ -134,13 +88,10 @@ const getScreenLockTimeout = async () => {
   }
 
   if (activePowerGUID) {
-    const ps = new Shell(shellOptions)
-    // ewwwwww
     const displayGUID = '7516b95f-f776-4464-8c53-06167f40cc99'
     const screenSleepGUID = '3c0bc021-c8a8-4e07-a973-6b14cbcb2b7e'
     const query = `powercfg /query ${activePowerGUID} ${displayGUID} ${screenSleepGUID}`
-    ps.addCommand(query)
-    const out = await ps.invoke()
+    const out = await execPowershell(query)
     const data = out.split(/([\r\n]+)/)
       .filter(i => i !== '\n')
       .map(l => l.trim().split(': '))
@@ -154,54 +105,28 @@ const getScreenLockTimeout = async () => {
       pluggedIn: parseInt(data['Current AC Power Setting Index'], 16) || Infinity,
       battery: parseInt(data['Current DC Power Setting Index'], 16) || Infinity
     }
-
-    ps.dispose()
   }
-
-  // cache for 10 seconds
-  cache.set('getScreenLockTimeout', response, 1000 * 10)
   return response
 }
 
 const getDisableLockWorkStation = async () => {
-  if (cache.get('getDisableLockWorkStation')) {
-    return cache.get('getDisableLockWorkStation')
-  }
-
   const commands = [
     '$name = "DisableLockWorkStation"',
     '$key = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System"',
     '(Get-ItemProperty -Path $key -Name $name).$name'
   ]
+  const output = await execPowershell(commands.join('; '))
 
-  const ps = new Shell(shellOptions)
-  ps.addCommand(commands.join('; '))
-
-  try {
-    const output = await ps.invoke()
-    cache.set('getDisableLockWorkStation', true, 1000 * 10)
-    ps.dispose()
-    return !!output
-  } catch (e) {
-    cache.set('getDisableLockWorkStation', false, 1000 * 10)
-    ps.dispose()
-    return false
-  }
+  return output !== UNKNOWN
 }
 
 const disks = async (disks = []) => {
-  if (cache.get('disks')) {
-    return cache.get('disks')
-  }
-
   const status = await Promise.all(
     disks.map(async ({ label }) => {
-      const ps = new Shell(shellOptions)
       let encrypted
 
       try {
-        ps.addCommand(`manage-bde -status ${label}`)
-        const out = await ps.invoke()
+        const out = await execPowershell(`manage-bde -status ${label}`)
         const data = out.split(/[\r\n]+/)
           .map(line =>
             line.trim().split(':').map(w => w.trim())
@@ -215,8 +140,6 @@ const disks = async (disks = []) => {
         encrypted = UNSUPPORTED
       }
 
-      ps.dispose()
-
       return {
         label,
         name: label,
@@ -224,9 +147,6 @@ const disks = async (disks = []) => {
       }
     })
   )
-
-  // cache for 10 minutes
-  cache.set('disks', status, 1000 * 60 * 10)
 
   return status
 }

--- a/src/lib/protocolHandlers.js
+++ b/src/lib/protocolHandlers.js
@@ -1,12 +1,13 @@
 const { protocol } = require('electron')
 const os = require('os')
+const log = require('./logger')
 const applescript = require('./applescript')
-const powershell = require('./powershell')
 const { shell } = require('electron')
 const env = process.env.NODE_ENV || 'production'
 
 module.exports = function initProtocols (mainWindow) {
   const { checkForUpdates } = require('../updater')(env, mainWindow)
+  const powershell = require('./powershell')
 
   protocol.registerHttpProtocol('app', (request, cb) => {
     applescript.openApp(decodeURIComponent(request.url.replace('app://', '')))
@@ -31,7 +32,7 @@ module.exports = function initProtocols (mainWindow) {
       try {
         checkForUpdates()
       } catch (e) {
-        console.log(e)
+        log.error(e)
       }
     }
   })

--- a/src/start.js
+++ b/src/start.js
@@ -1,8 +1,7 @@
 const { app, ipcMain, dialog, BrowserWindow, session, Tray, nativeImage } = require('electron')
 const path = require('path')
 const url = require('url')
-const winston = require('winston')
-require('winston-daily-rotate-file')
+const log = require('./lib/logger')
 const initMenu = require('./Menu')
 const initProtocols = require('./lib/protocolHandlers')
 const env = process.env.NODE_ENV || 'production'
@@ -25,30 +24,6 @@ const statusImages = {
   NUDGE: nativeImage.createFromPath(findIcon('scope-icon-nudge2@2x.png')),
   FAIL: nativeImage.createFromPath(findIcon('scope-icon-warn2@2x.png'))
 }
-
-// setup winston logging
-const transport = new (winston.transports.DailyRotateFile)({
-  filename: 'application-%DATE%.log',
-  datePattern: 'YYYY-MM-DD',
-  dirname: path.resolve(app.getPath('userData')),
-  zippedArchive: true,
-  maxSize: '20m',
-  maxFiles: '3d'
-})
-const consoleTransport = new winston.transports.Console()
-const log = new winston.Logger({
-  rewriters: [(level, msg, meta) => {
-    meta.version = pkg.version
-    return meta
-  }],
-  transports: [
-    transport,
-    consoleTransport
-  ]
-})
-
-// make the winston logger available to the renderer
-global.log = log
 
 // process command line arguments
 const enableDebugger = process.argv.find(arg => arg.includes('enableDebugger'))


### PR DESCRIPTION
Users reported Windows CPU usage was at 100% after running app. After investigating the issue, found that Powershell sessions were not being freed after queries and adding ~16 new children on each scan. This fixes the issue by calling `ps.dispose()` after each Powershell command. 

Verified that the number of processes drops to 3 (expected) after scan completes.