### PR TITLE
Fixed issue with violation badge not being reset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -149,6 +149,8 @@ class App extends Component {
       const violations = Object.keys(newState.result).filter(k => newState.result[k] === 'FAIL')
       const violationCount = violations.length > 1 ? violations.length - 1 : 1
       ipcRenderer.send('scan:violation', getBadge(violationCount), violationCount)
+    } else {
+      ipcRenderer.send('scan:violation', getBadge(0), 0)
     }
 
     this.setState(newState, () => {


### PR DESCRIPTION
Badge was still showing number of violations even after issues were resolved due to the view renderer only communicating the number of violations when they are greater than 0