### PR TITLE
Coerce the os_version so that it's always semver compliant

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const cors = require('cors')
 const bodyParser = require('body-parser')
 const fetch = require('isomorphic-fetch')
 const yaml = require('js-yaml')
+const semver = require('semver')
 
 const { graphql } = require('graphql')
 const { makeExecutableSchema } = require('graphql-tools')
@@ -89,7 +90,7 @@ module.exports = function startServer (env, log, appActions) {
       platform: os.platform() || process.platform,
       systemInfo: OSQuery.first('system_info'),
       platformInfo: OSQuery.first('platform_info'),
-      osVersion: OSQuery.first('os_version')
+      osVersion: OSQuery.first('os_version').then(v => v.version = semver.coerce(v.version))
     }
 
     const key = req.method === 'POST' ? 'body' : 'query'

--- a/server.js
+++ b/server.js
@@ -90,7 +90,10 @@ module.exports = function startServer (env, log, appActions) {
       platform: os.platform() || process.platform,
       systemInfo: OSQuery.first('system_info'),
       platformInfo: OSQuery.first('platform_info'),
-      osVersion: OSQuery.first('os_version').then(v => v.version = semver.coerce(v.version))
+      osVersion: OSQuery.first('os_version').then(v => {
+        v.version = semver.coerce(v.version)
+        return v
+      })
     }
 
     const key = req.method === 'POST' ? 'body' : 'query'


### PR DESCRIPTION
This was causing an error on MacOS 10.14 (since "10.14" is not a valid semver value).