### PR TITLE
Check root device for disk encryption

### DIFF
--- a/resolvers/platform/LinuxSecurity.js
+++ b/resolvers/platform/LinuxSecurity.js
@@ -11,8 +11,8 @@ module.exports = {
 
   async diskEncryption (root, args, context) {
     const disks = await OSQuery.all('disk_encryption', {
-      fields: ['*'],
-      where: 'name LIKE "%sda%" AND uuid != ""'
+      fields: ['encrypted'],
+      where: 'name = (select device from mounts where path = "/")'
     })
     return disks.every(({ encrypted }) => encrypted === "1")
   },


### PR DESCRIPTION
For now, assume that minimal full-disk encryption means that the device
mounted at '/' is encrypted. This is not complete and notably does not
cover the following scenarios:

* user has mounted an unencrypted device
* user has an unencrypted swap partition

For now, this seems a reasonable set of defaults.