### PR TITLE
Allow CLI to communicate with production app

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "mocha": "^5.2.0",
+    "node-fetch": "^2.2.0",
     "react-scripts": "^1.1.4",
     "standard": "^11.0.1"
   }

--- a/src/lib/Stethoscope.js
+++ b/src/lib/Stethoscope.js
@@ -53,7 +53,7 @@ export default class Stethoscope {
   }
 
   // privately retry request until a response is given
-  static __repeatRequest (policy, resolve, reject) {
+  static __repeatRequest (policy, origin = null, resolve, reject) {
     // TODO create and use fragments here
     const query = `query ValidateDevice($policy: DevicePolicy!) {
       policy {
@@ -121,9 +121,14 @@ export default class Stethoscope {
       }
     }`
 
+    const headers = { 'Content-Type': 'application/json' }
+    if (origin) {
+      headers.Origin = origin
+    }
+
     const options = {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: headers,
       body: JSON.stringify({ query, variables: { policy } })
     }
 
@@ -157,9 +162,9 @@ export default class Stethoscope {
   }
 
   // public API
-  static validate (policy) {
+  static validate (policy, origin = null) {
     return new Promise((resolve, reject) => {
-      this.__repeatRequest(policy, resolve, reject)
+      this.__repeatRequest(policy, origin, resolve, reject)
     })
   }
 }

--- a/stethoscope
+++ b/stethoscope
@@ -2,15 +2,25 @@
 require('babel-register')
 const yaml = require('js-yaml')
 const fs = require('fs')
-const fetch = require('node-fetch')
+global.fetch = require('node-fetch')
 const spacesToCamelCase = require('./src/lib/spacesToCamelCase')
 const Stethoscope = require('./src/lib/Stethoscope').default
 const action = process.argv[2]
 const policyArg = process.argv[3]
+const originArgIndex = process.argv.indexOf('--origin')
 
 if (!policyArg) {
   console.error('policy argument is required')
   process.exit(1)
+}
+
+let origin = 'stethoscope://main'  // default allowedHost configuration
+if (originArgIndex > 0) {
+  origin = process.argv[originArgIndex + 1]
+  if (!origin) {
+    console.error('--origin requires an argument')
+    process.exit(1)
+  }
 }
 
 switch (action) {
@@ -31,7 +41,7 @@ switch (action) {
       }
     }
 
-    Stethoscope.validate(policy).then(({ device, result }) => {
+    Stethoscope.validate(policy, origin).then(({ device, result }) => {
       const lastScanTime = Date.now()
       let output = {}
       if (process.argv.includes('--device-details')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5865,6 +5865,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"


### PR DESCRIPTION
By default, the stethoscope CLI will pass along an origin value of
'stethoscope://main' to validate(). This is the default allowedHosts
configuration, and if unchanged, will allow the CLI to talk to
production builds.

If a production build uses custom allowedHosts values, this header should be
configurable, so the CLI accepts an --origin flag.

Also, ensure 'node-fetch' is available.