### PR TITLE
Windows fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ The app is built with a default policy, which specifies recommended OS versions 
 
 This will work as a standalone checklist, without needing to report any data to a central server. In fact, it doesn’t even require internet connectivity.
 
-You can update the policy guidelines (OS versions, required settings, etc.) in [practices/policy.yaml](practices/policy.yaml), and change the instructions in [practices/instructions.yaml](practices/instructions.yaml).
+You can update the policy guidelines (OS versions, required settings, etc.) in [practices/policy.yaml](practices/policy.yaml), and change the instructions in [practices/instructions.en.yaml](practices/instructions.en.yaml).
 
 Queries from a website provide their own policy and policy variables.
+
+[Learn more about policies.](docs/POLICIES.md)
 
 ### Data collection and reporting
 

--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -39,6 +39,7 @@ input PlatformBracketRequirement {
   linux: VersionBracket
   all: VersionBracket
 }
+
 # defines the acceptable range of versions
 input VersionBracket {
   ok: Semver
@@ -62,7 +63,8 @@ The `RequirementOption` enum contains the following `ALWAYS`, `SUGGESTED`, `NEVE
 
 Scans return a JSON object with an overall status and individual practice status. Valid return values for a scan/practice are: `PASS`, `NUDGE`, and `FAIL`.
 
-e.g.
+**Example Response**
+
 ```json
 {
   "data": {

--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -144,8 +144,16 @@ You can use more complex semver strings if you want to warn on a specific OS ver
 ### `firewall` (yaml) | `firewall` (json)
 
 Firewall checks the local firewall state using the default firewall provider in each platform (and `iptables` on linux). This practice uses the `RequirementOption` enum to specify the requirement.
-.
+
 Valid values are: `ALWAYS`, `SUGGESTED`, `NEVER`, `IF_SUPPORTED`
+
+**Example Usage:**
+
+```json
+{
+  "firewall": "ALWAYS"
+}
+```
 
 ### `disk encryption` (yaml) | `diskEncryption` (json)
 
@@ -153,11 +161,27 @@ Disk encryption enumerates mounted drives and checks their encryption status usi
 
 Valid values are: `ALWAYS`, `SUGGESTED`, `NEVER`, `IF_SUPPORTED`
 
+**Example Usage:**
+
+```json
+{
+  "diskEncryption": "ALWAYS"
+}
+```
+
 ### `automatic updates` (yaml) | `automaticUpdates` (json)
 
 The automatic updates practice checks that the user has automatic updates enabled on their machine through `plist` values and service state (running). This practice uses the `RequirementOption` enum to specify the requirement.
 
 Valid values are: `ALWAYS`, `SUGGESTED`, `NEVER`, `IF_SUPPORTED`
+
+**Example Usage:**
+
+```json
+{
+  "automaticUpdates": "SUGGESTED"
+}
+```
 
 ### `screen lock` (yaml) | `screenLock` (json)
 
@@ -165,11 +189,27 @@ Does not work on El Capitan or higher as this setting was moved to the keychain 
 
 Valid values are: `ALWAYS`, `SUGGESTED`, `NEVER`, `IF_SUPPORTED`
 
+**Example Usage:**
+
+```json
+{
+  "screenLock": "IF_SUPPORTED"
+}
+```
+
 ### `remote login` (yaml) | `remoteLogin` (json)
 
 Checks that remote login (RDP, SSH) is disabled for the device. This practice uses the `RequirementOption` enum to specify the requirement.
 
 Valid values are: `ALWAYS`, `SUGGESTED`, `NEVER`, `IF_SUPPORTED`
+
+**Example Usage:**
+
+```json
+{
+  "remoteLogin": "NEVER"
+}
+```
 
 ### `required applications` (yaml) | `requiredApplications` (json)
 
@@ -195,7 +235,9 @@ input AppRequirement {
 }
 ```
 
-You can specify requirements as an array of `AppRequirements`. e.g.
+`name` is the only required property. You can specify requirements as an array of `AppRequirements`.
+
+**Example Usage:**
 
 ```json
 {

--- a/src/start.js
+++ b/src/start.js
@@ -108,7 +108,7 @@ function createWindow () {
   //   app.dock.show()
   // }
 
-  if (!IS_DEV) setTimeout(() => app.dock.hide(), 0)
+  if (!IS_DEV) setTimeout(() => app.dock && app.dock.hide(), 0)
 
   if (process.platform === 'win32') {
     deeplinkingUrl = process.argv.slice(1)

--- a/src/start.js
+++ b/src/start.js
@@ -37,7 +37,7 @@ const windowPrefs = {
   height: 670,
   fullscreenable: false,
   maximizable: false,
-  autoHideMenuBar: false,
+  autoHideMenuBar: true,
   skipTaskbar: true,
   // uncomment the line before to keep window controls but hide title bar
   // titleBarStyle: 'hidden',


### PR DESCRIPTION
- Fixes some issues with killing old osquery processes on Windows (use `taskkill` instead of `process.kill(pid)`). 
- Hide menu by default on Windows
- Updated documentation