### PR TITLE
Add support to query Browser extensions

### DIFF
--- a/resolvers/Device.js
+++ b/resolvers/Device.js
@@ -78,23 +78,36 @@ const Device = {
   },
 
   async extensions (root, args, context) {
-    const chrome = await OSQuery.all('chrome_extensions')
-    const ff = await OSQuery.all('firefox_addons')
+    const { browser = "all" } = args
+    let chrome = []
+    let firefox = []
     let safari = []
-    if (context.platform === 'darwin') {
-      safari = await OSQuery.all('safari_extensions')
+
+    if (['all', 'chrome'].includes(browser)) {
+      chrome = await OSQuery.all('chrome_extensions').then(results =>
+        results.map(({ name, version, identifier, path, author }) =>
+          ({ name, path, version, identifier, author, browser: 'chrome' })
+        )
+      )
     }
-    return [].concat(
-      chrome.map(
-        ({ name, version, identifier, path, author }) => ({ name, path, version, identifier, author, browser: 'chrome' })
-      ),
-      ff.map(
-        ({ name, version, identifier, path, creator: author }) => ({ name, path, version, identifier, author, browser: 'firefox' })
-      ),
-      safari.map(
-        ({ name, version, identifier, path, creator: author }) => ({ name, path, version, identifier, author, browser: 'safari' })
-      ),
-    )
+
+    if (['all', 'firefox'].includes(browser)) {
+      firefox = await OSQuery.all('firefox_addons').then(results =>
+        results.map(({ name, version, identifier, path, creator: author }) =>
+          ({ name, path, version, identifier, author, browser: 'firefox' })
+        )
+      )
+    }
+
+    if (['all', 'safari'].includes(browser)) {
+      safari = await OSQuery.all('safari_extensions').then(results =>
+        results.map(({ name, version, identifier, path, creator: author }) =>
+          ({ name, path, version, identifier, author, browser: 'safari' })
+        )
+      )
+    }
+
+    return chrome.concat(firefox).concat(safari)
   },
 
   async applications (root, args, context) {

--- a/resolvers/Device.js
+++ b/resolvers/Device.js
@@ -77,6 +77,26 @@ const Device = {
     return hardwareSerial
   },
 
+  async extensions (root, args, context) {
+    const chrome = await OSQuery.all('chrome_extensions')
+    const ff = await OSQuery.all('firefox_addons')
+    let safari = []
+    if (context.platform === 'darwin') {
+      safari = await OSQuery.all('safari_extensions')
+    }
+    return [].concat(
+      chrome.map(
+        ({ name, version, identifier, path, author }) => ({ name, path, version, identifier, author, browser: 'chrome' })
+      ),
+      ff.map(
+        ({ name, version, identifier, path, creator: author }) => ({ name, path, version, identifier, author, browser: 'firefox' })
+      ),
+      safari.map(
+        ({ name, version, identifier, path, creator: author }) => ({ name, path, version, identifier, author, browser: 'safari' })
+      ),
+    )
+  },
+
   async applications (root, args, context) {
     const os = PlatformResolvers[context.platform]
     if ('applications' in os) {

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,6 +36,8 @@ type Device {
   hardwareSerial: String
   # installed applications
   applications: [Application]
+  # browser extensions
+  extensions: [Extension]
   # current IP addresses
   ipAddresses: [IpAddress]
   # interface_details
@@ -86,6 +88,15 @@ type Application {
   version: String!
   lastOpenedTime: String
   installDate: String
+}
+
+type Extension {
+  name: String!
+  path: String!
+  version: String!
+  author: String!
+  identifier: String!
+  browser: String!
 }
 
 # A DevicePolicy is a description of the desired state of a set of pre-selected device features

--- a/schema.graphql
+++ b/schema.graphql
@@ -37,7 +37,7 @@ type Device {
   # installed applications
   applications: [Application]
   # browser extensions
-  extensions: [Extension]
+  extensions(browser: Browser): [Extension]
   # current IP addresses
   ipAddresses: [IpAddress]
   # interface_details
@@ -249,6 +249,13 @@ input PlatformBoolRequirement {
 input VersionBracket {
   ok: Semver
   nudge: Semver
+}
+
+enum Browser {
+  chrome
+  firefox
+  safari
+  all
 }
 
 # possible states that a device 'feature' can be in


### PR DESCRIPTION
Schema:

```graphql
type Extension {
  name: String!
  path: String!
  version: String!
  author: String!
  identifier: String!
  browser: String!
}
```

You can query for specific browsers: 

```graphql
query {
  device {
    extensions(browser: chrome) {
      name
      path
      identifier
      browser
    }
  }
}
```

Or leave off the filter to get extensions for all browsers:

```graphql
query {
  device {
    extensions {
      name
      path
      identifier
      browser
    }
  }
}
```