### PR TITLE
Stop binding to 'localhost' for node server

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 NODE_ENV=development
 BROWSER=none
+HOST=127.0.0.1

--- a/server.js
+++ b/server.js
@@ -224,7 +224,7 @@ module.exports = function startServer (env, log, language, appActions, OSQuery) 
   // const certificate = fs.readFileSync('./ssl/stethoscope.crt', 'utf8')
   // const creds = { key: privateKey, cert: certificate }
   // const httpsServer = https.createServer(creds, app)
-  const serverInstance = http.listen(PORT, 'localhost', () => {
+  const serverInstance = http.listen(PORT, '127.0.0.1', () => {
     console.log(`local server listening on ${PORT}`)
     serverInstance.emit('server:ready')
   })

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,7 +15,7 @@ const UNKNOWN = 'UNKNOWN'
 const UNSUPPORTED = 'UNSUPPORTED'
 
 const PORT = 37370
-const HOST = `http://localhost:${PORT}`
+const HOST = `http://127.0.0.1:${PORT}`
 
 module.exports = {
   PASS,

--- a/src/start-react.js
+++ b/src/start-react.js
@@ -4,7 +4,7 @@ const os = require('os')
 
 const port = process.env.PORT ? process.env.PORT - 100 : 12000
 
-process.env.ELECTRON_START_URL = `http://localhost:${port}`
+process.env.ELECTRON_START_URL = `http://127.0.0.1:${port}`
 
 const client = new net.Socket()
 


### PR DESCRIPTION
Also updated `.env` file so react scripts bind webpack to 127.0.0.1.

Resolves https://github.com/Netflix-Skunkworks/stethoscope-app/issues/62