### PR TITLE
2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Stethoscope",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "homepage": "./",
   "author": "Netflix",

--- a/server.js
+++ b/server.js
@@ -100,7 +100,6 @@ module.exports = function startServer (env, log, language, appActions, OSQuery) 
           version.push(v.patch)
         }
         v.version = semver.coerce(version.join('.'))
-        log.info('Version', v.version + '', 'Joined', version.join('.'), 'Coerced', semver.coerce(version.join('.')) + '')
         return v
       })
     }
@@ -131,6 +130,9 @@ module.exports = function startServer (env, log, language, appActions, OSQuery) 
 
     if (typeof policy === 'string') {
       policy = JSON.parse(policy)
+    }
+
+    if (Object.keys(policy).length) {
       // show the scan is happening in the UI
       io.sockets.emit('scan:init', { remote, remoteLabel })
     }

--- a/sources/osquery.js
+++ b/sources/osquery.js
@@ -6,7 +6,8 @@ const path = require('path')
 const log = require('../src/lib/logger')
 const ThriftClient = require('../src/lib/ThriftClient')
 const platform = os.platform()
-const IS_DEV = process.env.NODE_ENV === 'development'
+const { NODE_ENV, STETHOSCOPE_DEBUG } = process.env
+const IS_DEV = NODE_ENV === 'development'
 const OSQUERY_PID_PATH = `${app.getPath('userData')}${path.sep}.osquery.pid`
 
 const osqueryBinaries = {
@@ -28,7 +29,7 @@ const defaultOptions = {
   where: '1 = 1'
 }
 
-const debug = (...args) => log.info(`oquery: ${args.join(' ')}`)
+const debug = (...args) => STETHOSCOPE_DEBUG && STETHOSCOPE_DEBUG.includes('osquery') && log.info(`oquery: ${args.join(' ')}`)
 
 const cache = new Map()
 const timers = new Map()

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import classNames from 'classnames'
 import { HOST } from './constants'
 import { MAC } from './lib/platform'
 import appConfig from './config.json'
+import pkg from '../package.json'
 import ErrorMessage from './ErrorMessage'
 import './App.css'
 
@@ -57,6 +58,7 @@ class App extends Component {
   }
 
   async componentWillMount () {
+    document.querySelector('title').textContent += ` (v${pkg.version})`
     ipcRenderer.send('scan:init')
     // perform the initial policy load & scan
     await this.loadPractices()
@@ -138,6 +140,8 @@ class App extends Component {
       showNotification
     } = payload
 
+    const lastScanTime = Date.now()
+
     // device only scan with no policy completed
     if (noResults) {
       return this.setState({ loading: false, scannedBy: 'Stethoscope' })
@@ -152,6 +156,7 @@ class App extends Component {
 
       return this.setState({
         loading: false,
+        lastScanTime,
         errors: errors.map(({ message }) => message)
       })
     }
@@ -162,6 +167,7 @@ class App extends Component {
     let newState = {
       result: policy.validate,
       loading: false,
+      lastScanTime,
       remoteScan,
       scannedBy
     }
@@ -198,7 +204,6 @@ class App extends Component {
 
       Promise.all(promises).then(([config, policy, instructions]) => {
         this.setState({ config, policy, instructions }, () => {
-          log.info(JSON.stringify(this.state.policy))
           if (!this.state.scanIsRunning) {
             this.scan()
           }

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,8 @@ const OFF = 'OFF'
 const UNKNOWN = 'UNKNOWN'
 const UNSUPPORTED = 'UNSUPPORTED'
 
+const MINIMUM_AUTOSCAN_INTERVAL_SECONDS = 60 * 5
+
 const PORT = 37370
 const HOST = `http://127.0.0.1:${PORT}`
 
@@ -27,6 +29,8 @@ module.exports = {
   SUGGESTED,
   NEVER,
   IF_SUPPORTED,
+
+  MINIMUM_AUTOSCAN_INTERVAL_SECONDS,
 
   ON,
   OFF,


### PR DESCRIPTION
**Fixes**
[#61] lastScanTime does not update from remote scans
#63 Stop binding to 'localhost'
#64 Remove unused Applescript dependency in Mac resolver
#62 Remove all `localhost` dependencies