### PR TITLE
Cache fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,40 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](#)
 
+## [2.0.6](https://github.com/Netflix-Skunkworks/stethoscope-app/tree/v2.0.6)
+
+### Fixed
+- Stop binding to 'localhost' for node server, now explicitly bound to 127.0.0.1 to prevent host override issues
+- emit `scan:init` event on server, even if policy is not a string
+- updated react-dev-tools (vuln)
+- fixed cache timing issue, now auto expire cache once it is not in use
+
+### Changed
+- **changed method of checking disk encryption on mac to using `fdestatus` instead of osquery**
+- Removed unused Applescript import from MacSecurity resolver
+- quiet down verbose debug logging in osquery
+- optimize general queries that do not change between requests (run once)
+- differentiate main app errors with specific handlers
+
+### Added
+- Added version to app title to minimize users having to hunt the info down.
+- Added minimum rescan time
+- Added version to error page
+- Added error serialization to make logs less useless
+
 ----
 
-## [2.0.3](https://github.com/Netflix-Skunkworks/stethoscope-app/tree/2.0.3) - 2018-08-29
+## [2.0.5](https://github.com/Netflix-Skunkworks/stethoscope-app/tree/v2.0.5) - 2018-09-05
+
+### Fixes
+- Resolves Mojave instructions issue
+
+### Added
+- Support for querying Browser instructions documentation
+
+----
+
+## [2.0.3](https://github.com/Netflix-Skunkworks/stethoscope-app/tree/v2.0.3) - 2018-08-29
 
 -----
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Stethoscope",
-  "version": "2.0.1",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3861,7 +3861,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -5600,7 +5600,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5624,13 +5625,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5647,19 +5650,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5790,7 +5796,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5804,6 +5811,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5820,6 +5828,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5828,13 +5837,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5855,6 +5866,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5943,7 +5955,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5957,6 +5970,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6052,7 +6066,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6094,6 +6109,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6115,6 +6131,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6163,13 +6180,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11502,9 +11521,9 @@
       }
     },
     "react-dev-utils": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.1.tgz",
-      "integrity": "sha512-+y92rG6pmXt3cpcg/NGmG4w/W309tWNSmyyPL8hCMxuCSg2UP/hUg3npACj2UZc8UKVSXexyLrCnxowizGoAsw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.2.tgz",
+      "integrity": "sha512-d2FbKvYe4XAQx5gjHBoWG+ADqC3fGZzjb7i9vxd/Y5xfLkBGtQyX7aOb8lBRQPYUhjngiD3d49LevjY1stUR0Q==",
       "dev": true,
       "requires": {
         "address": "1.0.3",
@@ -11519,12 +11538,28 @@
         "inquirer": "3.3.0",
         "is-root": "1.0.0",
         "opn": "5.2.0",
-        "react-error-overlay": "^4.0.0",
+        "react-error-overlay": "^4.0.1",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
-        "sockjs-client": "1.1.4",
+        "sockjs-client": "1.1.5",
         "strip-ansi": "3.0.1",
         "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "sockjs-client": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+          "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.6.6",
+            "eventsource": "0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
+          }
+        }
       }
     },
     "react-dom": {
@@ -11539,9 +11574,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
-      "integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
+      "integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==",
       "dev": true
     },
     "react-is": {
@@ -12421,6 +12456,11 @@
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
+    },
+    "serialize-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
+      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -15020,6 +15060,16 @@
         "triple-beam": "^1.3.0",
         "winston-compat": "^0.1.4",
         "winston-transport": "^4.2.0"
+      },
+      "dependencies": {
+        "file-stream-rotator": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.3.1.tgz",
+          "integrity": "sha512-Vr6M5qmomoyJyjGEpvMJd74HWXe/6D1eB342QwJpb0WenGaBhe3IhzJQWzcKIEq5O3yYum45r4lYsQAm7cO1yA==",
+          "requires": {
+            "moment": "^2.11.2"
+          }
+        }
       }
     },
     "winston-transport": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "semver": "^5.4.1",
+    "serialize-error": "^2.1.0",
     "showdown": "^1.8.6",
     "socket.io": "^2.0.4",
     "thrift": "^0.11.0",
@@ -135,9 +136,9 @@
     "winston-daily-rotate-file": "^3.3.0"
   },
   "devDependencies": {
-    "@heroku/foreman": "^2.0.2",
     "@babel/core": "^7.0.0-rc.1",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0-rc.1",
+    "@heroku/foreman": "^2.0.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
@@ -147,6 +148,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "mocha": "^5.2.0",
+    "react-dev-utils": "5.0.2",
     "react-scripts": "^1.1.4",
     "standard": "^11.0.1"
   }

--- a/practices/policy.yaml
+++ b/practices/policy.yaml
@@ -5,10 +5,10 @@ osVersion:
     # Sierra
     nudge: ">=10.12.6"
   win32:
+    # Version 1803 - April 2018 Update
+    ok: ">=10.0.17134"
     # Version 1803 - Redstone 3 Fall Creators Update
-    ok: ">=10.0.16299"
-    # Version 1703 - Redstone 2 Creators Update
-    nudge: ">=10.0.15063"
+    nudge: ">=10.0.16299"
   ubuntu:
     ok: ">=18.4.0"
     nudge: ">=18.0.2"

--- a/resolvers/Device.js
+++ b/resolvers/Device.js
@@ -136,7 +136,9 @@ const Device = {
 
     const { isLocal, isMulticast, isPlaceholder } = NetworkInterface
 
-    return addresses.filter(({ mac }) => !isLocal(mac) && !isMulticast(mac) && !isPlaceholder(mac))
+    return addresses.filter(({ mac }) =>
+      !isLocal(mac) && !isMulticast(mac) && !isPlaceholder(mac)
+    )
   },
 
   async osqueryVersion (root, args, context) {

--- a/sources/osquery.js
+++ b/sources/osquery.js
@@ -31,7 +31,7 @@ const defaultOptions = {
 
 const debug = (...args) => STETHOSCOPE_DEBUG && STETHOSCOPE_DEBUG.includes('osquery') && log.info(`oquery: ${args.join(' ')}`)
 
-const CACHE_TIME = 5000
+const CACHE_TIMEOUT = 1000
 let clearCacheTimeout
 
 const cache = new Map()
@@ -282,7 +282,7 @@ class OSQuery {
 
         clearCacheTimeout = setTimeout(() => {
           this.flushCache()
-        }, CACHE_TIME)
+        }, CACHE_TIMEOUT)
 
         resolve(result)
       })

--- a/src/ErrorBoundary.js
+++ b/src/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import serializeError from 'serialize-error'
 
 let log = console
 let remote
@@ -18,7 +19,7 @@ export default class ErrorBoundary extends React.Component {
 
   componentDidCatch (error, info) {
     this.setState({ hasError: true })
-    log.error(error)
+    log.error(JSON.stringify(serializeError(error)))
   }
 
   render () {

--- a/src/ErrorMessage.js
+++ b/src/ErrorMessage.js
@@ -22,6 +22,7 @@ export default class ErrorMessage extends Component {
       <div className='error'>
         <h1>Oh no!</h1>
         <p>Something went wrong. Here's what we know:</p>
+        <pre>Stethoscope version: {this.props.version}</pre>
         <pre>{this.props.message + ''}</pre>
         {this.props.showStack ? <pre>{this.props.stack}</pre> : null}
         <button onClick={this.copyToClipboard}>Copy Error to Clipboard</button>

--- a/src/lib/Stethoscope.js
+++ b/src/lib/Stethoscope.js
@@ -150,7 +150,7 @@ export default class Stethoscope {
         if (err.message === 'retry') {
           return this.__repeatRequest(policy, resolve, reject)
         } else {
-          reject(err.message)
+          reject(err)
         }
       })
   }

--- a/src/lib/ThriftClient.js
+++ b/src/lib/ThriftClient.js
@@ -20,6 +20,10 @@ class ThriftClient {
     return this
   }
 
+  rebind(event, callback) {
+    return this.off(event, callback).on(event, callback)
+  }
+
   on (event, callback) {
     this._connection.on(event, callback)
     return this

--- a/yarn.lock
+++ b/yarn.lock
@@ -7007,6 +7007,29 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-dev-utils@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.2.tgz#7bb68d2c4f6ffe7ed1184c5b0124fcad692774d2"
+  dependencies:
+    address "1.0.3"
+    babel-code-frame "6.26.0"
+    chalk "1.1.3"
+    cross-spawn "5.1.0"
+    detect-port-alt "1.1.6"
+    escape-string-regexp "1.0.5"
+    filesize "3.5.11"
+    global-modules "1.0.0"
+    gzip-size "3.0.0"
+    inquirer "3.3.0"
+    is-root "1.0.0"
+    opn "5.2.0"
+    react-error-overlay "^4.0.1"
+    recursive-readdir "2.2.1"
+    shell-quote "1.6.1"
+    sockjs-client "1.1.5"
+    strip-ansi "3.0.1"
+    text-table "0.2.0"
+
 react-dev-utils@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-5.0.1.tgz#1f396e161fe44b595db1b186a40067289bf06613"
@@ -7042,6 +7065,10 @@ react-dom@^16.2.0:
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+
+react-error-overlay@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
 
 react-is@^16.4.0:
   version "16.4.0"
@@ -7567,6 +7594,10 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
+serialize-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -7764,6 +7795,17 @@ socket.io@^2.0.4:
 sockjs-client@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.4.tgz#5babe386b775e4cf14e7520911452654016c8b12"
+  dependencies:
+    debug "^2.6.6"
+    eventsource "0.1.6"
+    faye-websocket "~0.11.0"
+    inherits "^2.0.1"
+    json3 "^3.3.2"
+    url-parse "^1.1.8"
+
+sockjs-client@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.1.5.tgz#1bb7c0f7222c40f42adf14f4442cbd1269771a83"
   dependencies:
     debug "^2.6.6"
     eventsource "0.1.6"


### PR DESCRIPTION
- fixed cache timing issue, now auto expire cache once it is not in use
- changed method of checking disk encryption on mac to using `fdestatus`
instead of osquery
- optimize general queries that do not change between requests
- differentiate main app errors with specific handlers
- Add version to error page
- updated react-dev-tools (vuln)
- added error serialization to make logs less useless