### PR TITLE
Socket path update

### DIFF
--- a/sources/osquery.js
+++ b/sources/osquery.js
@@ -18,7 +18,7 @@ const osqueryBinaries = {
 }
 
 const socketPaths = {
-  darwin: `/tmp/osquery.em`,
+  darwin: `/private/tmp/osquery.em`,
   ubuntu: `/tmp/osquery.em`,
   linux: `/tmp/osquery.em`,
   win32: `\\\\.\\pipe\\osquery.em`

--- a/src/Action.js
+++ b/src/Action.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import ReactDOMServer from 'react-dom/server'
 import Accessible from './Accessible'
 import ActionIcon from './ActionIcon'
-import Handlebars from 'handlebars'
+import Handlebars from 'handlebars/dist/cjs/handlebars'
 import semver from 'semver'
 import showdown from 'showdown'
 

--- a/src/lib/thrift/Pool.js
+++ b/src/lib/thrift/Pool.js
@@ -112,7 +112,7 @@ const pooledRpc = (TService, rpc, pool) => (...args) => {
 
 const DEFAULT_POOL_OPTIONS = {
   max: 1,
-  min: 0,
+  min: 1,
   idleTimeoutMillis: 30000,
   acquireTimeoutMillis: 10000,
   testOnBorrow: true,
@@ -123,7 +123,7 @@ const DEFAULT_THRIFT_OPTIONS = {
   transport: Thrift.TFramedTransport,
   protocol: Thrift.TBinaryProtocol,
   connect_timeout: 1000,
-  max_attempts: 3,
+  max_attempts: 10,
 };
 
 /* Entrypoint */

--- a/src/start.js
+++ b/src/start.js
@@ -58,6 +58,7 @@ const BASE_URL = process.env.ELECTRON_START_URL || url.format({
 // process command line arguments
 const enableDebugger = process.argv.find(arg => arg.includes('enableDebugger'))
 const DEBUG_MODE = !!process.env.STETHOSCOPE_DEBUG
+const DEBUG_UI = (process.env.STETHOSCOPE_DEBUG || '').split(',').map(s => s.trim()).includes('ui')
 
 const focusOrCreateWindow = () => {
   if (mainWindow && !mainWindow.isDestroyed()) {
@@ -106,7 +107,7 @@ function createWindow () {
   mainWindow = new BrowserWindow(windowPrefs)
 
   // open developer console if env vars or args request
-  if (enableDebugger || DEBUG_MODE) mainWindow.webContents.openDevTools()
+  if (enableDebugger || DEBUG_UI) mainWindow.webContents.openDevTools()
 
   updater = require('./updater')(env, mainWindow, log, OSQuery, server)
 


### PR DESCRIPTION
- Moved socket path to userData directory
- Use osquery's pidfile arg instead of self-managing.
- Changed minimum thrift connections to 1 and increased min retries. 
- Fixed handlebars warning. 
- Made UI/osquery debugging more granular. (e.g. `export STETHOSCOPE_DEBUG=ui,osquery`)
