### PR TITLE
Fix for osquery Linux path #92 

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "target": "AppImage",
       "category": "System",
       "extraResources": [
-        "bin/osqueryi_linux"
+        "bin/osqueryd_linux"
       ],
       "files": [
         "practices/*",


### PR DESCRIPTION
Fixed the reference of the **osqueryd_linux** binary for LInux. Fixes https://github.com/Netflix-Skunkworks/stethoscope-app/issues/92