### PR TITLE
Fix kmd quoting for OS version on linux

### DIFF
--- a/sources/linux/os.sh
+++ b/sources/linux/os.sh
@@ -5,7 +5,7 @@ extract NAME="(.*)"
 save system.platform
 
 load output
-extract VERSION_ID=(.*)
+extract VERSION_ID="*([\d\.]+)"*
 save system.version
 remove output
 


### PR DESCRIPTION
```shell
❯ ./test-all.sh
testing sources/linux/os.sh...
alpine: {"system":{"platform":"Alpine Linux","version":"3.6.3","build":"4.9.125-linuxkit"}}
ubuntu: {"system":{"platform":"Ubuntu","version":"18.04","build":"4.9.125-linuxkit"}}
centos: {"system":{"platform":"CentOS Linux","version":"7","build":"4.9.125-linuxkit"}}
```