### PR TITLE
Remote-login kmd source for linux

### DIFF
--- a/sources/linux/remote-login.sh
+++ b/sources/linux/remote-login.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env kmd
+exec ss -ltn
+trim
+extract :(2[23])\s
+save remoteLogin


### PR DESCRIPTION
netstat is deprecated on most systems, in favor of ss

```shell
ubuntu: {"remoteLogin":"22"}
fedora: {"remoteLogin":"22"}
```