### PR TITLE
MAC-address kmd source for linux

### DIFF
--- a/sources/linux/mac-addresses.sh
+++ b/sources/linux/mac-addresses.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env kmd
+exec ifconfig
+trim
+split \n\n
+  save _line
+  extract (\w+):\s
+  save device
+
+  load _line
+  extract .*(..:..:..:..:..:..)
+  save addr
+
+  remove _line
+noEmpty
+save macAddresses


### PR DESCRIPTION
```shell
fedora: {"macAddresses":[{"device":"enp0s3","addr":"08:00:27:eb:5a:a2"},{"device":"lo"},{"device":"virbr0","addr":"52:54:00:ee:46:10"}]}
ubuntu: {"macAddresses":[{"device":"enp0s3","addr":"08:00:27:2c:5a:90"},{"device":"lo"}]}
```