### PR TITLE
Hardware version kmd source for linux

### DIFF
--- a/sources/linux/hardwareVersion.sh
+++ b/sources/linux/hardwareVersion.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env kmd
+
+exec cat /sys/devices/virtual/dmi/id/board_vendor /sys/devices/virtual/dmi/id/board_name
+save output
+extract (\w+)\n
+defaultTo Unavailable
+save boardVendor
+
+load output
+extract .+\n(\w+)
+defaultTo Unavailable
+save boardName
+
+template {boardVendor} {boardName}
+save system.hardwareVersion
+remove output
+remove boardVendor
+remove boardName


### PR DESCRIPTION
Tested on ubuntu and centos.

A few items in the `system` group will be unavailable without root: `deviceId` (BIOS UUID) and `serialNumber` in particular, I think will need to report 'Unavailable'.