### PR TITLE
AutoUpdate kmd source for Ubuntu

### DIFF
--- a/sources/linux/ubuntu/critical-updates.sh
+++ b/sources/linux/ubuntu/critical-updates.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env kmd
+exec cat /etc/apt/apt.conf.d/20auto-upgrades
+save output
+extract APT::Periodic::Update-Package-Lists "(\d)";
+defaultTo 0
+save updates.configDataInstall
+
+load output
+extract APT::Periodic::Unattended-Upgrade "(\d)";
+defaultTo 0
+save updates.criticalUpdateInstall
+
+remove output
+save updates


### PR DESCRIPTION
This mechanism will be different for Fedora (`dnf-automatic`) and Centos/RHEL (`yum-cron`), so this is probably the first `kmd` script that needs to be broken out into a distro-specific folder. It is assumed that the `kmd`-loader will source the appropriate distro and/or version subfolders in addition to the platform, though distro and version detection is not currently implemented.