### PR TITLE
System UUID kmd source for linux

### DIFF
--- a/sources/linux/deviceId.sh
+++ b/sources/linux/deviceId.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env kmd
+
+exec cat /etc/machine-id
+trim
+save system.uuid

--- a/sources/linux/hardwareVersion.sh
+++ b/sources/linux/hardwareVersion.sh
@@ -2,12 +2,12 @@
 
 exec cat /sys/devices/virtual/dmi/id/board_vendor /sys/devices/virtual/dmi/id/board_name
 save output
-extract (\w+)\n
+extract (.+)\n
 defaultTo Unavailable
 save boardVendor
 
 load output
-extract .+\n(\w+)
+extract .+\n(.+)
 defaultTo Unavailable
 save boardName
 

--- a/sources/linux/serialNumber.sh
+++ b/sources/linux/serialNumber.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env kmd
+
+echo Unavailable
+save system.serialNumber

--- a/sources/linux/ubuntu/critical-updates.sh
+++ b/sources/linux/ubuntu/critical-updates.sh
@@ -11,4 +11,3 @@ defaultTo 0
 save updates.criticalUpdateInstall
 
 remove output
-save updates


### PR DESCRIPTION
Also:
* fix a bug with system dot-prop getting truncated when merging multiple
sources.
* improve hardwareVersion detection (allow spaces, e.g. Red Hat)
* show chassis serialNumber as unavailable (requires root access)

tested on fedora 28 and Ubuntu 18.04