### PR TITLE
Disks kmd source for linux

### DIFF
--- a/sources/linux/disks.sh
+++ b/sources/linux/disks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env kmd
+exec lsblk --fs --pairs
+trim
+lines
+  save _line
+  extract NAME="([\w-]+)"\s
+  save name
+
+  load _line
+  extract UUID="([\w-]+)"\s
+  save uuid
+
+  load _line
+  extract FSTYPE="([\w-]+)"\s
+  save type
+
+  remove _line
+noEmpty
+save disks.volumes


### PR DESCRIPTION
Shows volume details for filesystem-bearing block devices

Tested on Fedora and Ubuntu, generates output of the form:
```
{
  "disks": {
    "volumes": [
      {
        "name": "sda"
      },
      {
        "name": "sda1",
        "uuid": "add33c8e-71f0-413c-9d5d-70028273e876",
        "type": "ext4"
      },
      {
        "name": "sda2",
        "uuid": "adHUyq-tH5g-rF1i-5wB6-RDI2-Q4Wa-FqMkNw",
        "type": "LVM2_member"
      },
      {
        "name": "sr0",
        "uuid": "2018-07-16-15-16-03-09",
        "type": "iso9660"
      },
      {
        "name": "fedora-root",
        "uuid": "900bfd6a-4255-4510-9bba-2353ca5936cf",
        "type": "ext4"
      },
      {
        "name": "fedora-swap",
        "uuid": "43c78622-5a2c-4718-a005-e0151a5beaa9",
        "type": "swap"
      },
      {
        "name": "fedora-home",
        "uuid": "2e329e40-fa82-40ca-bc27-b854caf6be69",
        "type": "ext4"
      }
    ]
  }
}
```