### PR TITLE
Disk encryption kmd source for linux

### DIFF
--- a/sources/linux/encryption.sh
+++ b/sources/linux/encryption.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env kmd
+exec lsblk -f
+trim
+contains crypt
+save disks.encryption


### PR DESCRIPTION
Forced-pushed to refactor against the new `contains` kmd. 

Tested with Ubuntu and Fedora.