### PR TITLE
Regex fix for firewall detection in Linux

### DIFF
--- a/sources/linux/firewall.sh
+++ b/sources/linux/firewall.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env kmd
 exec lsmod
-extract ip6?t_REJECT\s+\d+\s+(\d)
+trim
+extract ip6*t_REJECT\s+\d+\s+(\d)
 save firewallEnabled


### PR DESCRIPTION
It appears that the previous regex wasn't matching properly for non-IPV6 kernel modules. This appears to work better.

```
[vagrant@localhost mnt]$ sudo ufw enable
Firewall is active and enabled on system startup
[vagrant@localhost mnt]$ kmd ./firewall.sh 
{"firewallEnabled":"1"}
[vagrant@localhost mnt]$ sudo ufw disable
Firewall stopped and disabled on system startup
[vagrant@localhost mnt]$ kmd ./firewall.sh 
{"firewallEnabled":"0"}
```
