### PR TITLE
Resolve friendlyName for Linux devices

### DIFF
--- a/resolvers/platform/LinuxDevice.js
+++ b/resolvers/platform/LinuxDevice.js
@@ -1,4 +1,7 @@
 module.exports = {
+  async friendlyName (root, args, { kmdResponse }) {
+    return kmdResponse.system.hardwareVersion
+  },
   async disks (root, args, { kmdResponse }) {
     return kmdResponse.disks.volumes
   },


### PR DESCRIPTION
This resolves `friendlyName` for Linux devices to `system.hardwareVersion`, and improves  the Device summary in the header bar for this platform.

<img width="355" alt="screen shot 2019-02-23 at 11 23 04 am" src="https://user-images.githubusercontent.com/513523/53288953-740ce880-375d-11e9-8ca7-69b8d8bd2a73.png">
