### PR TITLE
Patch semver module to support Canonical versions

### DIFF
--- a/resolvers/NumericRange.js
+++ b/resolvers/NumericRange.js
@@ -1,5 +1,5 @@
 const { GraphQLScalarType } = require('graphql')
-const semver = require('semver')
+const semver = require('../src/lib/patchedSemver')
 
 // NumericRange is an alias for the Semver scalar type
 

--- a/resolvers/Security.js
+++ b/resolvers/Security.js
@@ -1,4 +1,4 @@
-const semver = require('semver')
+const semver = require('../src/lib/patchedSemver')
 const pkg = require('../package.json')
 const { NUDGE, UNSUPPORTED } = require('../src/constants')
 const { Security: PlatformResolvers } = require('./platform/')

--- a/resolvers/Semver.js
+++ b/resolvers/Semver.js
@@ -1,5 +1,5 @@
 const { GraphQLScalarType } = require('graphql')
-const semver = require('semver')
+const semver = require('../src/lib/patchedSemver')
 
 const Semver = new GraphQLScalarType({
   name: 'Semver',

--- a/resolvers/platform/MacSecurity.js
+++ b/resolvers/platform/MacSecurity.js
@@ -1,4 +1,4 @@
-const semver = require('semver')
+const semver = require('../../src/lib/patchedSemver')
 const Device = require('./MacDevice')
 const pkg = require('../../package.json')
 const { exec } = require('child_process')

--- a/resolvers/platform/WindowsSecurity.js
+++ b/resolvers/platform/WindowsSecurity.js
@@ -1,4 +1,4 @@
-const semver = require('semver')
+const semver = require('../../src/lib/patchedSemver')
 const Device = require('../platform/WindowsDevice')
 const pkg = require('../../package.json')
 const { NUDGE, UNKNOWN } = require('../../src/constants')

--- a/src/Action.js
+++ b/src/Action.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import ReactDOMServer from 'react-dom/server'
 import Accessible from './Accessible'
 import ActionIcon from './ActionIcon'
-import semver from 'semver'
+import semver from './lib/patchedSemver'
 import showdown from 'showdown'
 import Handlebars from 'handlebars/dist/handlebars.min.js';
 

--- a/src/lib/patchedSemver.js
+++ b/src/lib/patchedSemver.js
@@ -1,0 +1,49 @@
+// This patches a long-standing issue with npm/semver:
+// https://github.com/npm/node-semver/issues/232
+//
+// The motivator for this change was supporting Canonical version strings like:
+// '16.04', '18.04', etc. These do not parse with npm/semver because they have
+// a leading zero in the minor version.  Similarly, version constraints like
+// '>=18.04' fail to match coerced version values like '18.4.0' This
+// "decorator" solves both of these issues, but should be removed if the
+// upstream project someday supports Canonical-style versions.
+
+const semver = require('semver');
+
+const LeadingZeroRE = new RegExp(/0+(\d+)/, "g");
+
+function removeLeadingZeros(numeric) {
+  return numeric.replace(LeadingZeroRE, "$1");
+}
+
+function trimLeadingSemVerZeros(trimStr) {
+  return trimStr.split('.').map(removeLeadingZeros).join('.');
+}
+
+function coerceMajorMinorPatch(coerceStr) {
+  const versions = coerceStr.split('.');
+  for (let i = versions.length; i < 3; i++) {
+    versions.push(0);
+  }
+  return versions.join('.');
+}
+
+function safeStr(input) {
+  if (typeof input === 'string') {
+    return coerceMajorMinorPatch(trimLeadingSemVerZeros(input));
+  }
+  return input; // clean passthru for coerced semver objects
+}
+
+const origCoerce = semver.coerce;
+const origSatisfies = semver.satisfies;
+
+semver.coerce = function (str) {
+  return origCoerce(safeStr(str));
+}
+
+semver.satisfies = function(version, constraint) {
+  return origSatisfies(safeStr(version), safeStr(constraint));
+}
+
+module.exports = semver;


### PR DESCRIPTION
e.g.:
semver.coerce('16.04')
semver.valid(semver.coerce('18.04'))
semver.satisfies('18.04', '>=16.04')