### PR TITLE
Resolve screenLock and screenIdle for Linux

### DIFF
--- a/practices/instructions.en.yaml
+++ b/practices/instructions.en.yaml
@@ -182,6 +182,11 @@ practices:
         1. Ensure that "Users must enter a user name and password to use this computer" is checked.
         1. Click "Apply".
         1. Click "OK".
+      linux: |
+        1. From the upper-right drop-down menu, click the Settings icon.
+        1. In the left-hand pane, select Privacy.
+        1. Click on ScreenLock
+        1. Ensure that "Automatic Screen Lock" is set to ON.
 
   screenIdle:
     title:  >
@@ -198,6 +203,12 @@ practices:
         1. Click Desktop & Screen Saver.
         1. Click the [Screen Saver](open:///System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane/) tab.
         1. Adjust the "Start after" dropdown to less than or equal to the number of seconds shown below.
+        {{securitySetting "screenIdle"}}
+      linux: |
+        1. From the upper-right drop-down menu, click the Settings icon.
+        1. In the left-hand pane, select Privacy.
+        1. Click on ScreenLock
+        1. Adjust the "Lock screen after blank" dropdown to less than or equal to the number of seconds shown below.
         {{securitySetting "screenIdle"}}
 
   osVersion:

--- a/resolvers/platform/LinuxSecurity.js
+++ b/resolvers/platform/LinuxSecurity.js
@@ -1,4 +1,5 @@
 const { UNKNOWN } = require('../../src/constants')
+const semver = require('semver')
 
 module.exports = {
   async firewall (root, args, { kmdResponse }) {
@@ -18,5 +19,15 @@ module.exports = {
       return updates.criticalUpdateInstall === "1"
     }
     return UNKNOWN
+  },
+
+  async screenLock (root, args, { kmdResponse }) {
+    return kmdResponse.screen.lockEnabled === 'true'
+  },
+
+  async screenIdle (root, args, { kmdResponse }) {
+    const idleDelay = kmdResponse.screen.lockDelay
+    return kmdResponse.screen.idleActivationEnabled === 'true' &&
+     semver.satisfies(semver.coerce(idleDelay), args.screenIdle)
   }
 }

--- a/sources/linux/screen.sh
+++ b/sources/linux/screen.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env kmd
+exec gsettings list-recursively org.gnome.desktop.screensaver
+trim
+save output
+
+extract lock-enabled (.*)
+save screen.lockEnabled
+
+load output
+extract logout-delay uint\d+ (\d+)
+save screen.logoutDelay
+
+load output
+extract lock-delay uint\d+ (\d+)
+save screen.lockDelay
+
+load output
+extract idle-activation-enabled (.*)
+save screen.idleActivationEnabled
+
+load output
+extract ubuntu-lock-on-suspend (.*)
+defaultTo UNSUPPORTED
+save screen.lockOnSuspend
+
+remove output


### PR DESCRIPTION
This adds a `kmd` source for screensaver settings, resolvers for `screenLock` and `screenIdle`, as well as instructions for configuring these values in Gnome.