### PR TITLE
Minor fixes for Linux

### DIFF
--- a/resolvers/platform/LinuxSecurity.js
+++ b/resolvers/platform/LinuxSecurity.js
@@ -15,7 +15,7 @@ module.exports = {
 
   async automaticUpdates (root, args, { kmdResponse }) {
     if (kmdResponse.updates) {
-      return updates.criticalUpdateInstall === "1"
+      return kmdResponse.updates.criticalUpdateInstall === "1"
     }
     return UNKNOWN
   }

--- a/sources/linux/firmwareVersion.sh
+++ b/sources/linux/firmwareVersion.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env kmd
+echo Unavailable
+save system.firmwareVersion


### PR DESCRIPTION
Adds system.firmware source, so device resolver doesn't return 'null' on
Linux platform.

Typo fix for critical update resolver.