### PR TITLE
Fix AutoLaunch for Linux AppImages

### DIFF
--- a/src/AutoLauncher.js
+++ b/src/AutoLauncher.js
@@ -1,12 +1,16 @@
 const settings = require('electron-settings')
 const AutoLaunch = require('auto-launch')
 const config = require('./config.json')
+const os = require('os');
 
 class AutoLauncher {
   constructor () {
     const autoLaunchOpts = {
       name: 'Stethoscope',
       isHidden: true
+    }
+    if (os.platform() === 'linux' && process.env.APPIMAGE) {
+      autoLaunchOpts.path = process.env.APPIMAGE
     }
     this.stethoscopeAutoLauncher = new AutoLaunch(autoLaunchOpts)
   }


### PR DESCRIPTION
per https://github.com/Teamwork/node-auto-launch/issues/89,
this resolves the desktop autostart path to the executable, which
defaulted to current working path of the running process. Due to the
AppImage architecture, that default doesn't work cleanly and requires
override.