### PR TITLE
Expand first failed item by default

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -10,7 +10,7 @@ const converter = new showdown.Converter()
 
 class Action extends Component {
   state = {
-    showDescription: false
+    showDescription: this.props.expandedByDefault
   }
 
   constructor (props) {

--- a/src/Device.js
+++ b/src/Device.js
@@ -41,7 +41,7 @@ class Device extends Component {
   actions (actions, type, device) {
     const status = type === 'done' ? 'PASS' : 'FAIL'
 
-    return actions.map((action) => {
+    return actions.map((action, index) => {
       const actionProps = {
         action,
         device,
@@ -51,7 +51,8 @@ class Device extends Component {
         onExpandPolicyViolation: this.props.onExpandPolicyViolation,
         platform: this.props.platform,
         policy: this.props.policy,
-        security: this.props.security
+        security: this.props.security,
+        expandedByDefault: type === 'critical' && index === 0
       }
 
       const hasResults = Array.isArray(action.results)


### PR DESCRIPTION
Expand the first failed check by default.

Adds functionality for #82 