### PR TITLE
Switch to using `kmd@0.0.8` `tryExec` command when iterating disks.

### DIFF
--- a/sources/darwin/disks.sh
+++ b/sources/darwin/disks.sh
@@ -18,7 +18,8 @@ split \n\n
   # each disk has to be run through
   # diskutil info to get the uuid
   template diskutil info '{_path}'
-  exec
+  tryExec
+  defaultTo
   extract Partition UUID:\s+([A-Z0-9-]+)
   save uuid
 


### PR DESCRIPTION
Resolves an issue where Stethoscope fails for Mac users that have connected but ejected disks.

This can be merged once [this PR](https://github.com/Netflix-Skunkworks/kmd/pull/7) on `kmd` is merged an published.