### PR TITLE
Do not kill the application when the main window is closed on mac

### DIFF
--- a/src/start.js
+++ b/src/start.js
@@ -373,4 +373,10 @@ process.on('uncaughtException', err => {
   process.exit(1)
 })
 
+app.on('window-all-closed', () => {
+  if (!IS_MAC) {
+    app.quit()
+  }
+})
+
 export {}

--- a/src/start.js
+++ b/src/start.js
@@ -27,7 +27,7 @@ import initProtocols from './lib/protocolHandlers'
 import loadReactDevTools from './lib/loadReactDevTools'
 import iconFinder from './lib/findIcon'
 import startGraphQLServer from './server'
-import { IS_MAC, IS_WIN } from './lib/platform'
+import { IS_LINUX, IS_MAC, IS_WIN } from './lib/platform'
 import AutoLauncher from './AutoLauncher'
 import updateInit from './updater'
 
@@ -374,8 +374,8 @@ process.on('uncaughtException', err => {
 })
 
 app.on('window-all-closed', () => {
-  if (!IS_MAC) {
-    app.quit()
+  if (IS_LINUX) {
+    app.quit();
   }
 })
 


### PR DESCRIPTION
The default behavior for the `event-window-all-closed` has changed. 

In order not to kill the application the event needs to be overridden.

https://electronjs.org/docs/api/app#event-window-all-closed