### PR TITLE
Corrects the code formatting in the window-all-closed event

### DIFF
--- a/src/start.js
+++ b/src/start.js
@@ -375,7 +375,7 @@ process.on('uncaughtException', err => {
 
 app.on('window-all-closed', () => {
   if (IS_LINUX) {
-    app.quit();
+    app.quit()
   }
 })
 


### PR DESCRIPTION
I missed this little linting issue in https://github.com/Netflix-Skunkworks/stethoscope-app/pull/148