### PR TITLE
Added open wifi policy

### DIFF
--- a/docs/POLICIES.md
+++ b/docs/POLICIES.md
@@ -245,3 +245,17 @@ input AppRequirement {
   }]
 }
 ```
+
+### `openWifiConnections`
+
+Checks if there are old wifi connections cached locally. This practice uses the `RequirementOption` enum to specify the requirement.
+
+Valid values are: `ALWAYS`, `SUGGESTED`, `NEVER`, `IF_SUPPORTED`
+
+**Example Usage:**
+
+```json
+{
+  "openWifiConnections": "SUGGESTED"
+}
+```

--- a/schema.graphql
+++ b/schema.graphql
@@ -146,6 +146,7 @@ input DevicePolicy {
   stethoscopeVersion: Semver
   # [WINDOWS ONLY] optional maximum screenlock timeout (in seconds)
   windowsMaxScreenLockTimeout: Int
+  openWifiConnections: RequirementOption
 }
 
 # Defines a requirement for an installed application
@@ -186,6 +187,8 @@ type PolicyResult {
   applications: [ApplicationFeatureState]
   # stethoscope is up-to-date
   stethoscopeVersion: FeatureState
+  # Open Wi-Fi
+  openWifiConnections: FeatureState
 }
 
 type Security {
@@ -207,6 +210,7 @@ type Security {
   publicFirewall(requirement: RequirementOption!): Boolean!
   privateFirewall(requirement: RequirementOption!): Boolean!
   domainFirewall(requirement: RequirementOption!): Boolean!
+  openWifiConnections(requirement: RequirementOption!): Boolean!
 }
 
 type IpAddress {

--- a/src/lib/Stethoscope.js
+++ b/src/lib/Stethoscope.js
@@ -66,6 +66,7 @@ export default class Stethoscope {
           automaticUpdates
           remoteLogin
           stethoscopeVersion
+          openWifiConnections
 
           applications {
             name

--- a/src/practices/instructions.en.yaml
+++ b/src/practices/instructions.en.yaml
@@ -251,3 +251,20 @@ practices:
 
       win32: |
         See the following requirements:
+
+  openWifiConnections:
+    title: >
+      {{#if passing}}
+        There are no open Wi-Fi networks cached locally
+      {{else}}
+        There are open Wi-Fi networks cached locally
+      {{/if}}
+    description: >
+      Unprotected Wi-Fi networks are a common attack vector for man-in-the-middle attacks. If you connect to an unprotected Wi-Fi hotspot once, your computer will then try to connect to any access point with a matching name in the future. An attacker can then simply spoof that network name and proxy all of the network traffic from the computer.
+    directions:
+      darwin: |
+        1. Choose [System Preferences](x-apple.systempreferences:com.apple.systempreferences) from the Apple menu.
+        1. Click Network.
+        1. Click on the Wi-Fi connection in the left pane
+        1. Click on "Advanced..."
+        1. Find and remove the networks that has Security set to "None"

--- a/src/practices/policy.yaml
+++ b/src/practices/policy.yaml
@@ -24,3 +24,4 @@ automaticUpdates: SUGGESTED
 screenLock: IF_SUPPORTED
 screenIdle: "<=120"
 remoteLogin: NEVER
+openWifiConnections: SUGGESTED

--- a/src/resolvers/Security.js
+++ b/src/resolvers/Security.js
@@ -175,5 +175,12 @@ export default {
     }
 
     return UNSUPPORTED
+  },
+
+  async openWifiConnections (root, args, context) {
+    if ('openWifiConnections' in PlatformSecurity) {
+      return PlatformSecurity.openWifiConnections(root, args, context)
+    }
+    return UNSUPPORTED
   }
 }

--- a/src/resolvers/platform/MacSecurity.js
+++ b/src/resolvers/platform/MacSecurity.js
@@ -1,6 +1,6 @@
 import { NUDGE, DEFAULT_DARWIN_APP_PATH } from '../../constants'
 import kmd from '../../lib/kmd'
-import os from 'os';
+import os from 'os'
 
 const MacSecurity = {
   async automaticAppUpdates (root, args, context) {
@@ -34,15 +34,15 @@ const MacSecurity = {
   },
 
   async applications (root, args, context) {
-    const requests = args.applications.map(({name, paths = {}}) => {
+    const requests = args.applications.map(({ name, paths = {} }) => {
       const variables = {
         NAME: name,
         PATH: (paths.darwin || DEFAULT_DARWIN_APP_PATH).replace(/^~/, os.homedir())
       }
-      return kmd('app', context, variables);
-    });
-    const results = await Promise.all(requests);
-    return results;
+      return kmd('app', context, variables)
+    })
+    const results = await Promise.all(requests)
+    return results
   },
 
   async automaticUpdates (root, args, context) {
@@ -97,6 +97,11 @@ const MacSecurity = {
   async firewall (root, args, context) {
     const result = await kmd('firewall', context)
     return parseInt(result.firewallEnabled, 10) > 0
+  },
+
+  async openWifiConnections (root, args, context) {
+    const result = await kmd('openWifiConnections', context)
+    return result.wifiConnections === 'Closed'
   }
 
   // await kmd('app', context)

--- a/src/sources/darwin/openWifiConnections.sh
+++ b/src/sources/darwin/openWifiConnections.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env kmd
+exec defaults read /Library/Preferences/SystemConfiguration/com.apple.airport.preferences
+extract .*Open.*
+extract Open
+
+defaultTo Closed
+save wifiConnections

--- a/src/sources/darwin/openWifiConnections.sh
+++ b/src/sources/darwin/openWifiConnections.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env kmd
-exec defaults read /Library/Preferences/SystemConfiguration/com.apple.airport.preferences
-extract .*Open.*
+exec cat /Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist
 extract Open
 
 defaultTo Closed


### PR DESCRIPTION
We added a security practice that will check if there are any old open Wi-Fi connections on computer.

This was tested and developed on macOS Mojave 10.14.5.

The practice is mac only (for now).