### PR TITLE
Fixes crash when clicking on a app store link

### DIFF
--- a/src/lib/applescript.js
+++ b/src/lib/applescript.js
@@ -21,7 +21,7 @@ const openApp = async function (appName) {
   return execString(script)
 }
 
-export {
+export default {
   openPreferences,
   openApp
 }


### PR DESCRIPTION
The app crashed when clicking on App Store links.

<img width="503" alt="Screenshot 2019-07-16 at 11 29 43" src="https://user-images.githubusercontent.com/7823236/61283254-21d86c80-a7bd-11e9-932b-773abc3cb6cf.png">

```
error: exiting on uncaught exception
11:11:43 AM electron.1 |  error: Cannot read property 'openApp' of undefined
11:11:43 AM electron.1 |  error: TypeError: Cannot read property 'openApp' of undefined
11:11:43 AM electron.1 |      at Function.openApp (/Users/cfp/code/repos/stethoscope-app/compiled/lib/protocolHandlers.js:13:72)
``` 

This fixes the bug.

