### PR TITLE
Safegaurd against window being closed when requesting an update

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -26,7 +26,7 @@ export default function (mainWindow, app, focusOrCreateWindow, updater, log) {
           label: 'Open Window',
           accelerator: 'CmdOrCtrl+N',
           click () {
-            focusOrCreateWindow()
+            mainWindow = focusOrCreateWindow(mainWindow)
           }
         }
       ]

--- a/src/start.js
+++ b/src/start.js
@@ -78,7 +78,7 @@ const BASE_URL = process.env.ELECTRON_START_URL || url.format({
 let enableDebugger = process.argv.find(arg => arg.includes('enableDebugger'))
 const DEBUG_MODE = !!process.env.STETHOSCOPE_DEBUG
 
-const focusOrCreateWindow = () => {
+const focusOrCreateWindow = (mainWindow) => {
   if (mainWindow && !mainWindow.isDestroyed()) {
     if (mainWindow.isMinimized()) {
       mainWindow.restore()
@@ -89,6 +89,7 @@ const focusOrCreateWindow = () => {
     initMenu(mainWindow, app, focusOrCreateWindow, updater, log)
     mainWindow.loadURL(BASE_URL)
   }
+  return mainWindow;
 }
 
 async function createWindow () {
@@ -115,7 +116,7 @@ async function createWindow () {
   }
 
   // required at run time so dependencies can be injected
-  updater = updateInit(env, mainWindow, log, server)
+  updater = updateInit(env, mainWindow, log, server, focusOrCreateWindow)
 
   if (isLaunching) {
     updater.checkForUpdates({}, {}, {}, true)
@@ -145,7 +146,7 @@ async function createWindow () {
   if (tray) tray.destroy()
 
   tray = new Tray(statusImages.PASS)
-  tray.on('click', focusOrCreateWindow)
+  tray.on('click', () => focusOrCreateWindow(mainWindow))
 
   tray.on('right-click', () => tray.popUpContextMenu(initMenu(mainWindow, app, focusOrCreateWindow, updater, log)))
 

--- a/src/updater.js
+++ b/src/updater.js
@@ -9,7 +9,7 @@ const eventRegistration = {}
 // NOTE:
 // The actual updating only happens in prod - electron updates (due to Squirrel)
 // must be signed, so the process always fails in dev
-export default function updater (env, mainWindow, log = console, server) {
+export default function updater (env, mainWindow, log = console, server, focusOrCreateWindow) {
   let updater
   autoUpdater.autoDownload = false
   if (config.allowPrerelease) {
@@ -42,6 +42,7 @@ export default function updater (env, mainWindow, log = console, server) {
       }, (buttonIndex) => {
         if (buttonIndex === 0) {
           if (!isDev) {
+            mainWindow = focusOrCreateWindow(mainWindow)
             autoUpdater.downloadUpdate()
           } else {
             if (updater) updater.enabled = true


### PR DESCRIPTION
When the application window has been closed and an update is requested the app crashes since the mainWindow object has been destroyed. This safeguards against operations on the mainWindow object to ensure it exists.

Also a small refactor to return a new mainWindow from the create or focus method so it can be set in the context of consuming modules.