### PR TITLE
Add node-fetch to fix copy debug info fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "js-yaml": "^3.10.0",
     "kmd-script": "^0.0.11",
     "moment": "^2.19.3",
+    "node-fetch": "^2.6.0",
     "node-powershell": "^3.3.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,5 +1,5 @@
-/* global fetch */
 import { Menu, shell, clipboard } from 'electron'
+import fetch from 'node-fetch';
 import pkg from '../package.json'
 import config from './config.json'
 import AutoLauncher from './AutoLauncher'

--- a/yarn.lock
+++ b/yarn.lock
@@ -9033,6 +9033,11 @@ node-abi@^2.7.0:
   dependencies:
     semver "^5.4.1"
 
+node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"


### PR DESCRIPTION
**BUG**
Copy Debug Info fails and crashes the app

**CAUSE**
The menu module runs in node and fetch is not natively supported. This causes the fetch in the click handler to crash the app.

**FIX**
Add `node-fetch` to give fetch functionality in node