### PR TITLE
Mac auto update check to be fail resistant and use appropriate flags

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -76,6 +76,8 @@ type SecurityInfo {
   automaticDownloadUpdates: FeatureState
   # whether system config data is set to auto update
   automaticConfigDataInstall: FeatureState
+
+  automaticCheckEnabled: FeatureState
   # Windows
   publicFirewall: FeatureState
   # Windows
@@ -207,6 +209,7 @@ type Security {
   automaticAppUpdates(requirement: RequirementOption!): Boolean!
   automaticDownloadUpdates(requirement: RequirementOption!): Boolean!
   automaticConfigDataInstall(requirement: RequirementOption!): Boolean!
+  automaticCheckEnabled(requirement: RequirementOption!): Boolean!
   publicFirewall(requirement: RequirementOption!): Boolean!
   privateFirewall(requirement: RequirementOption!): Boolean!
   domainFirewall(requirement: RequirementOption!): Boolean!

--- a/src/__tests__/policy-server.js
+++ b/src/__tests__/policy-server.js
@@ -125,6 +125,7 @@ describe('GraphQL', () => {
           automaticOsUpdates
           automaticDownloadUpdates
           automaticConfigDataInstall
+          automaticCheckEnabled
         }
       }
     }`

--- a/src/lib/Stethoscope.js
+++ b/src/lib/Stethoscope.js
@@ -115,6 +115,7 @@ export default class Stethoscope {
           automaticOsUpdates
           automaticDownloadUpdates
           automaticConfigDataInstall
+          automaticCheckEnabled
         }
       }
     }`

--- a/src/practices/instructions.en.yaml
+++ b/src/practices/instructions.en.yaml
@@ -132,12 +132,12 @@ practices:
         {{/if}}
         1. Click "Automatically check for updates"
         {{#unless passing}}
-        1. Make sure the following are checked:
+          1. Make sure the following are checked:
 
-        - {{{statusIcon automaticUpdates 'Automatically check for updates'}}}
-          - {{{statusIcon automaticDownloadUpdates 'Download newly available updates in the background'}}}
-          - {{{statusIcon automaticAppUpdates 'Install app updates'}}}
+          - {{{statusIcon automaticCheckEnabled 'Automatically check for updates'}}}
+          - {{{statusIcon automaticDownloadUpdates 'Download new updates when available'}}}
           - {{{statusIcon automaticOsUpdates 'Install macOS updates'}}}
+          - {{{statusIcon automaticAppUpdates 'Install app updates from the App Store'}}}
           - {{{statusIcon automaticSecurityUpdates 'Install system data files and \*security updates\*'}}}
         {{/unless}}
 

--- a/src/resolvers/Device.js
+++ b/src/resolvers/Device.js
@@ -174,6 +174,11 @@ const Device = {
         return securityToDeviceStatus(status)
       },
 
+      async automaticCheckEnabled () {
+        const status = await Security.automaticCheckEnabled(root, args, context)
+        return securityToDeviceStatus(status)
+      },
+
       async diskEncryption () {
         const status = await Security.diskEncryption(root, args, context)
         return securityToDeviceStatus(status)

--- a/src/resolvers/Security.js
+++ b/src/resolvers/Security.js
@@ -42,6 +42,14 @@ export default {
     return UNSUPPORTED
   },
 
+  async automaticCheckEnabled (root, args, context) {
+    if ('automaticCheckEnabled' in PlatformSecurity) {
+      return PlatformSecurity.automaticCheckEnabled(root, args, context)
+    }
+
+    return UNSUPPORTED
+  },
+
   async automaticSecurityUpdates (root, args, context) {
     if ('automaticSecurityUpdates' in PlatformSecurity) {
       return PlatformSecurity.automaticSecurityUpdates(root, args, context)

--- a/src/resolvers/platform/MacSecurity.js
+++ b/src/resolvers/platform/MacSecurity.js
@@ -24,8 +24,8 @@ const MacSecurity = {
   },
 
   async automaticOsUpdates (root, args, context) {
-    const result = await kmd('com.apple.commerce', context)
-    return result.updates.restartRequired !== '0'
+    const result = await kmd('com.apple.SoftwareUpdate', context)
+    return result.updates.automaticallyInstallMacOSUpdates !== '0'
   },
 
   async automaticCheckEnabled (root, args, context) {

--- a/src/sources/darwin/com.apple.SoftwareUpdate.sh
+++ b/src/sources/darwin/com.apple.SoftwareUpdate.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env kmd
-exec defaults read /Library/Preferences/com.apple.SoftwareUpdate.plist
+tryExec defaults read /Library/Preferences/com.apple.SoftwareUpdate.plist
+defaultTo
 save output
 extract CriticalUpdateInstall\s+=\s+([\d]+);
-defaultTo 1
+defaultTo 0
 save updates.criticalUpdateInstall
 
 load output
 extract AutomaticCheckEnabled\s+=\s+([\d]+);
-defaultTo 1
+defaultTo 0
 save updates.automaticCheckEnabled
 
 load output
 extract ConfigDataInstall\s+=\s+([\d]+);
-defaultTo 1
+defaultTo 0
 save updates.configDataInstall
 
 load output
 extract AutomaticDownload\s+=\s+([\d]+);
-defaultTo 1
+defaultTo 0
 save updates.automaticDownload
+
+load output
+extract AutomaticallyInstallMacOSUpdates\s+=\s+([\d]+);
+defaultTo 0
+save updates.automaticallyInstallMacOSUpdates
 
 remove output
 save updates

--- a/src/sources/darwin/com.apple.commerce.sh
+++ b/src/sources/darwin/com.apple.commerce.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env kmd
-exec defaults read /Library/Preferences/com.apple.commerce.plist
+tryExec defaults read /Library/Preferences/com.apple.commerce.plist
+defaultTo
 save line
 extract AutoUpdateRestartRequired\s+=\s+([\d]+);
-defaultTo 1
+defaultTo 0
 save updates.restartRequired
 
 load line
 extract AutoUpdate\s+=\s+([\d]+);
-defaultTo 1
+defaultTo 0
 save updates.autoUpdate
 
 remove line


### PR DESCRIPTION
On new mac computers (>=10.14.6) the `com.apple.commerce.plist` file will not exist until the configs have changed for that file. This causes Stethoscope to crash and not respond since the script assumes this file exists.

Computers that have made that config change and older computers updating are not seeing this issue since the file exists on disk.

This PR also updates some of the properties referenced to be in line with shat settings are toggled in the settings.

Some language updates as well to be more aligned with the new mac settings panel