### PR TITLE
Implement applications resolver for win32

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -26,6 +26,8 @@ const DEFAULT_DARWIN_APP_PATH = '/Applications'
 const DEFAULT_WIN32_APP_PATH = '\\Program Files'
 const DEFAULT_LINUX_APP_PATH = '/usr/share'
 
+const DEFAULT_WIN32_APP_REGISTRY_PATH = 'HKLM\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall'
+
 // Application states
 const VALID = 'VALID'
 const INVALID_INSTALL_STATE = 'INVALID_INSTALL_STATE'

--- a/src/resolvers/Security.js
+++ b/src/resolvers/Security.js
@@ -216,6 +216,7 @@ export default {
           version: installed ? data.version : undefined,
           installed,
           passing: state === VALID,
+          reason: data.reason,
           state
         }
       })

--- a/src/resolvers/platform/MacSecurity.js
+++ b/src/resolvers/platform/MacSecurity.js
@@ -104,51 +104,6 @@ const MacSecurity = {
     return result.wifiConnections === 'Closed'
   }
 
-  // await kmd('app', context)
-  //  async applications (root, args, context) {
-  //   const apps = await Device.applications(root, args, context)
-  //   const { version: osVersion } = context.kmdResponse.system
-  //   const { applications = [] } = args
-  //
-  //   return applications.filter((app) => {
-  //     const { platform = false } = app
-  //     // if a platform is required
-  //     if (platform) {
-  //       if (platform[context.platform]) {
-  //         return patchedSemver.satisfies(osVersion, platform[context.platform])
-  //       },
-  //       return platform.all
-  //     },
-  //     // no platform specified - default to ALL
-  //     return true
-  //   }).map(({
-  //     exactMatch = false,
-  //     name,
-  //     version,
-  //     platform,
-  //     // ignored for now
-  //     includePackages
-  //   }) => {
-  //     let userApp
-  //
-  //     if (!exactMatch) {
-  //       userApp = apps.find((app: IApp) => (new RegExp(name, 'ig')).test(app.name))
-  //     } else {
-  //       userApp = apps.find((app: IApp) => app.name === name)
-  //     },
-  //
-  //     // app isn't installed - fail
-  //     if (!userApp) {
-  //       return { name, passing: false, reason: 'NOT_INSTALLED' },
-  //     },
-  //     // app is out of date - fail
-  //     if (version && !patchedSemver.satisfies(userApp.version, version)) {
-  //       return { name, passing: false, reason: 'OUT_OF_DATE' },
-  //     },
-  //
-  //     return { name, passing: true },
-  //   })
-  // },
 }
 
 export default MacSecurity

--- a/src/resolvers/platform/WindowsDevice.js
+++ b/src/resolvers/platform/WindowsDevice.js
@@ -8,9 +8,5 @@ export default {
 
   async disks (root, args, context) {
     return null
-  },
-
-  async applications (root, args, context) {
-    return null
   }
 }

--- a/src/sources/win32/apps.sh
+++ b/src/sources/win32/apps.sh
@@ -1,5 +1,5 @@
 #/usr/bin/env kmd
-exec reg query 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall'
+exec reg query '%REGISTRY_PATH%'
 trim
 lines
   save _line
@@ -12,17 +12,17 @@ lines
   save name
   save displayName
 
-  load output
+  load _output
   extract Publisher\s+[A-Z\s_]+\s+(.*)
   save publisher
 
-  load output
+  load _output
   extract InstallDate\s+[A-Z\s_]+\s+(.*)
   parseDate YYYYMMDD
   save installDate
 
-  load output
-  extract DisplayVersion\s+[A-Z\s_]+\s+(\d+\.\d+\.\d+)
+  load _output
+  extract DisplayVersion\s+[A-Z\s_]+\s+(.*)
   save version
 
   remove _output


### PR DESCRIPTION
In this resolver context, specifying a policy like:

```json
{
  "applications": [
    {
      "name": "someapp",
      "assertion": "ALWAYS",
      "paths": {
        "win32": "\\\\SOME\\\\REGISTRY\\\\PATH"
      }
    }
  ]
}
```

the 'paths.win32' string here indicates that the resolver should look in
that registry location for installation data. Most likely, this
shouldn't need to be specified, and the querent may rely on the default
resolver registry path.

NOTE: platform filtering is not yet working. The applications policy
schema needs an update which will occur under a separate PR.