### PR TITLE
fix: environment variable typo in BUILDS.md

### DIFF
--- a/docs/BUILDS.md
+++ b/docs/BUILDS.md
@@ -35,7 +35,7 @@ By default, Stethoscope builds will **not** notarize your application. If you wo
 
     // if using a jwt
     export APPLE_API_KEY='myapikey'
-    export APPLE_API_KEY_ISSUER='myissuer'
+    export APPLE_API_ISSUER='myissuer'
 
     // optional
     export ASC_PROVIDER='myascprovider'


### PR DESCRIPTION
Matches `appleApiIssuer` from Electron Notarize. The Mac build exits with this error when using the old environment variable:

```
⨯ APPLE_API_KEY and APPLE_API_ISSUER env vars are required  stackTrace=
                                                                Error: APPLE_API_KEY and APPLE_API_ISSUER env vars are required
```