### PR TITLE
Only strip *leading* zeros in patchedSemver. Fixes #199.

### DIFF
--- a/src/lib/patchedSemver.js
+++ b/src/lib/patchedSemver.js
@@ -10,7 +10,7 @@
 
 import semver from 'semver'
 
-const LeadingZeroRE = new RegExp(/0+(\d+)/, 'g')
+const LeadingZeroRE = new RegExp(/^0+(\d+)/, 'g')
 
 function removeLeadingZeros (numeric) {
   return numeric.replace(LeadingZeroRE, '$1')


### PR DESCRIPTION
This code was removing intermediate zeros, not just leading zeros. Therefore, Windows version 10.0.19041 was being  converted to `10.0.1941`, which is less than `10.0.18363`.