### PR TITLE
Bump OS versions

### DIFF
--- a/src/practices/policy.yaml
+++ b/src/practices/policy.yaml
@@ -1,14 +1,14 @@
 osVersion:
   darwin:
-    # Latest Mojave or Catalina
-    ok: ">=10.15.7"
-    # Sierra
-    nudge: ">=10.12.6"
+    # Big Sur
+    ok: ">=11.0"
+    # Catalina
+    nudge: ">=10.15.7"
   win32:
-    # Version 1809
-    ok: ">=10.0.17763"
-    # Version 1803
-    nudge: ">=10.0.17134"
+    # Version 20H2
+    ok: ">=10.0.19042"
+    # Version 2004
+    nudge: ">=10.0.19041"
   awsWorkspace:
     ok: ">=10.0.14393"
     nudge: ">=10.0.10240"


### PR DESCRIPTION
Bump Windows and Mac to current versions.
Windows nudge has been out since 5/2020