### PR TITLE
Fix the screenlock check for Linux

### DIFF
--- a/src/sources/linux/screen.sh
+++ b/src/sources/linux/screen.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env kmd
+exec gsettings list-recursively org.gnome.desktop.session
+trim
+save output
+
+extract idle-delay uint\d+ (\d+)
+save screen.idleDelay
+remove output
+
 exec gsettings list-recursively org.gnome.desktop.screensaver
 trim
 save output


### PR DESCRIPTION
As per [GNOME documentation for screensaver settings](https://github.com/GNOME/gsettings-desktop-schemas/blob/master/schemas/org.gnome.desktop.screensaver.gschema.xml.in), `idle-activation-enabled` is deprecated and is ignored. Instead we need to check that `idle-delay` is set to `> 0`.

- Check idle-delay to determine if the session is set to become idle after a period of inactivity.
- Calculate the total delay to screen lock as `idle-delay + lock-delay`