### PR TITLE
add deprecation notice

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react'
 import Stethoscope from './lib/Stethoscope'
 import Device from './Device'
+import DeprecationNotice from './DeprecationNotice'
 import Loader from './Loader'
 import Footer from './Footer'
 import DownloadProgress from './DownloadProgress'
@@ -370,6 +371,10 @@ class App extends Component {
 
     return (
       <div className={classNames('App', { loading })}>
+        <DeprecationNotice
+          config={this.state.config || {}}
+          handleOpenExternal={this.handleOpenExternal}
+        />
         {content}
       </div>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -373,7 +373,7 @@ class App extends Component {
       <div className={classNames('App', { loading })}>
         <DeprecationNotice
           config={this.state.config || {}}
-          handleOpenExternal={this.handleOpenExternal}
+          onHandleOpenExternal={this.handleOpenExternal}
         />
         {content}
       </div>

--- a/src/DeprecationNotice.css
+++ b/src/DeprecationNotice.css
@@ -1,0 +1,7 @@
+.deprecation-notice {
+  font-size: 18px;
+  background: #fbfafa;
+  border-color: #ecdede;
+  padding: 15px;
+  color: #9a211d;
+}

--- a/src/DeprecationNotice.js
+++ b/src/DeprecationNotice.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import './DeprecationNotice.css'
+
+export default function Footer(props) {
+  const { config, handleOpenExternal } = props
+  const { heading, subHeading, linkUrl, linkText } =
+    config.deprecationNotice || {}
+
+  return (
+    <div className='deprecation-notice'>
+      <p>{heading}</p>
+      <p>{subHeading}</p>
+      <p>
+        <a onClick={handleOpenExternal} href={linkUrl}>
+          {linkText}
+        </a>
+      </p>
+    </div>
+  )
+}

--- a/src/DeprecationNotice.js
+++ b/src/DeprecationNotice.js
@@ -7,14 +7,18 @@ export default function Footer (props) {
     config.deprecationNotice || {}
 
   return (
-    <div className='deprecation-notice'>
-      <p>{heading}</p>
-      <p>{subHeading}</p>
-      <p>
-        <a onClick={onHandleOpenExternal} href={linkUrl}>
-          {linkText}
-        </a>
-      </p>
+    <div>
+      {config.deprecationNotice && (
+        <div className='deprecation-notice'>
+          <p>{heading}</p>
+          <p>{subHeading}</p>
+          <p>
+            <a onClick={onHandleOpenExternal} href={linkUrl}>
+              {linkText}
+            </a>
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/DeprecationNotice.js
+++ b/src/DeprecationNotice.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import './DeprecationNotice.css'
 
-export default function Footer(props) {
-  const { config, handleOpenExternal } = props
+export default function Footer (props) {
+  const { config, onHandleOpenExternal } = props
   const { heading, subHeading, linkUrl, linkText } =
     config.deprecationNotice || {}
 
@@ -11,7 +11,7 @@ export default function Footer(props) {
       <p>{heading}</p>
       <p>{subHeading}</p>
       <p>
-        <a onClick={handleOpenExternal} href={linkUrl}>
+        <a onClick={onHandleOpenExternal} href={linkUrl}>
           {linkText}
         </a>
       </p>

--- a/src/practices/config.yaml
+++ b/src/practices/config.yaml
@@ -7,3 +7,9 @@ policyServer:
 testHosts:
   # - url: "http://foo.bar.com"
   #   label: Display Value
+deprecationNotice:
+  heading: >
+    The Stethocsope Desktop application is deprecated and no longer supported.
+  subHeading:
+  linkUrl:
+  linkText:

--- a/src/practices/config.yaml
+++ b/src/practices/config.yaml
@@ -7,9 +7,3 @@ policyServer:
 testHosts:
   # - url: "http://foo.bar.com"
   #   label: Display Value
-deprecationNotice:
-  heading: >
-    The Stethoscope Desktop application is deprecated and no longer supported.
-  subHeading:
-  linkUrl:
-  linkText:

--- a/src/practices/config.yaml
+++ b/src/practices/config.yaml
@@ -9,7 +9,7 @@ testHosts:
   #   label: Display Value
 deprecationNotice:
   heading: >
-    The Stethocsope Desktop application is deprecated and no longer supported.
+    The Stethoscope Desktop application is deprecated and no longer supported.
   subHeading:
   linkUrl:
   linkText:


### PR DESCRIPTION
Add a deprecation notice indicating that the Stethoscope app is no longer supported.
Provide the ability to specify a subHeading, linkText, and a linkUrl, so that organizations can provide a custom message

![Stethoscope (v5 0 5) 2022-05-25 18-16-05](https://user-images.githubusercontent.com/1182738/170384663-41f9e37c-b92a-4909-8f3a-e422bc737ad0.png)

